### PR TITLE
Add **kwargs to multi to support preload options

### DIFF
--- a/celery/bin/multi.py
+++ b/celery/bin/multi.py
@@ -469,7 +469,7 @@ class MultiTool(TermLogger):
 )
 @click.pass_context
 @handle_preload_options
-def multi(ctx):
+def multi(ctx, **kwargs):
     """Start multiple worker instances."""
     cmd = MultiTool(quiet=ctx.obj.quiet, no_color=ctx.obj.no_color)
     # In 4.x, celery multi ignores the global --app option.


### PR DESCRIPTION
*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryproject.org/en/master/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against master, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in master, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->

When daemonising celery using `multi start worker`, custom preload options will trigger an error as the `multi` function does not accept keyword arguments. Although the keyword arguments are ignored for this command, it does solve the issue and adheres to the preload option's mantra: gets passed to every command.